### PR TITLE
Updates apache2-utils to version 2.4.38-r3

### DIFF
--- a/phlex/Dockerfile
+++ b/phlex/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /opt
 # Setup base
 RUN \
   apk add --no-cache \
-    apache2-utils=2.4.35-r0 \
+    apache2-utils=2.4.38-r3 \
     nginx=1.14.2-r0 \
     php7-curl=7.2.13-r0 \
     php7-fileinfo=7.2.13-r0 \


### PR DESCRIPTION

# Proposed Changes

This PR will update `apache2-utils` to version `2.4.38-r3`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
