### PR TITLE
Updates php7-openssl to version 7.2.14-r0

### DIFF
--- a/phlex/Dockerfile
+++ b/phlex/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     php7-fpm=7.2.13-r0 \
     php7-json=7.2.13-r0 \
     php7-opcache=7.2.13-r0 \
-    php7-openssl=7.2.13-r0 \
+    php7-openssl=7.2.14-r0 \
     php7-phar=7.2.13-r0 \
     php7-session=7.2.13-r0 \
     php7-sockets=7.2.13-r0 \


### PR DESCRIPTION

# Proposed Changes

This PR will update `php7-openssl` to version `7.2.14-r0`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
