### PR TITLE
Updates php7-sockets to version 7.2.18-r0

### DIFF
--- a/phlex/Dockerfile
+++ b/phlex/Dockerfile
@@ -20,7 +20,7 @@ RUN \
     php7-openssl=7.2.17-r0 \
     php7-phar=7.2.17-r0 \
     php7-session=7.2.17-r0 \
-    php7-sockets=7.2.17-r0 \
+    php7-sockets=7.2.18-r0 \
     php7-sqlite3=7.2.17-r0 \
     php7-zip=7.2.17-r0 \
     php7-simplexml=7.2.17-r0 \


### PR DESCRIPTION

# Proposed Changes

This PR will update `php7-sockets` to version `7.2.18-r0`.

This PR was created automatically, please check the "Files changed" tab
before merging!

***

This PR was created with [repoupdater][repoupdater] :tada:

[repoupdater]: https://pypi.org/project/repoupdater/
